### PR TITLE
Missing Puppet facts can be both nil and :undefined

### DIFF
--- a/lib/hiera/backend/aws/base.rb
+++ b/lib/hiera/backend/aws/base.rb
@@ -11,16 +11,16 @@ class Hiera
           @scope = scope
         end
 
+        attr_reader :scope
+
         def aws_region
-          @scope["location"] || "eu-west-1"
+          puppet_fact("location") || "eu-west-1"
         end
 
         def aws_account_number
-          @scope["aws_account_number"] ||
+          puppet_fact("aws_account_number") ||
             AWS::IAM.new.users.first.arn.split(":")[4]
         end
-
-        attr_reader :scope
 
         def lookup(key, scope)
           @scope = scope
@@ -30,6 +30,12 @@ class Hiera
             # Found no handler for key
             nil
           end
+        end
+
+        def puppet_fact(name)
+          fact = scope[name]
+          return nil if fact == :undefined
+          fact
         end
       end
     end

--- a/spec/aws_base_spec.rb
+++ b/spec/aws_base_spec.rb
@@ -52,6 +52,23 @@ class Hiera
           expect(service.aws_account_number).to eq "12345678"
         end
       end
+
+      describe "#puppet_fact" do
+        it "returns value of Puppet fact if fact exists" do
+          service = Aws::Base.new "some-fact" => "some-value"
+          expect(service.puppet_fact "some-fact").to eq "some-value"
+        end
+
+        it "returns nil if Puppet fact is nil" do
+          service = Aws::Base.new
+          expect(service.puppet_fact "some-fact").to eq nil
+        end
+
+        it "returns nil if Puppet fact is undefined" do
+          service = Aws::Base.new "some-fact" => :undefined
+          expect(service.puppet_fact "some-fact").to eq nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- When calling `hiera` from the command line, missing facts are `nil`.
- When calling `hiera` from Puppet code, missing facts are `:undefined`.
