### PR TITLE
Return nil instead of empty results to bail out in Puppet run

### DIFF
--- a/lib/hiera/backend/aws_backend.rb
+++ b/lib/hiera/backend/aws_backend.rb
@@ -30,7 +30,7 @@ class Hiera
           next unless service_class
 
           value = service_class.lookup(key, scope)
-          next unless value
+          next if value.nil? || value.empty?
 
           answer = Backend.parse_answer(value, scope)
           break if answer

--- a/spec/aws_backend_spec.rb
+++ b/spec/aws_backend_spec.rb
@@ -57,6 +57,14 @@ class Hiera
           expect_any_instance_of(Aws::RDS).to receive(:lookup).with(key, scope)
           backend.lookup(*params)
         end
+
+        it "returns nil if service returns empty result" do
+          empty_result = []
+          Backend.stub(:datasources).and_yield "aws/rds"
+          Backend.stub(:parse_answer).and_return(empty_result)
+          Aws::RDS.stub(:new).and_return(double(:lookup => empty_result))
+          expect(backend.lookup(*params)).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
With this change, calls to `hiera` that don't return any data, e.g. when no RDS instances can be found, will cause the Puppet run to fail (400 error), allowing us to catch problems early.

Example of a failing Puppet run:

```
err: Could not retrieve catalog from remote server: Error 400 on SERVER:
Could not find data item rds jimdo:environment=geloet in any Hiera data file and no default supplied at 
/var/lib/puppet/environments/hiera_empty_result/modules/profile/manifests/common/puppet/master.pp:37 on node xxx.eu-west-1.aws.jimdo-server.com
warning: Not using cache on failed catalog
err: Could not retrieve catalog; skipping run
```

Now one has to explicitly define a default value, e.g. [], to get an empty dataset.

Inspired by
- http://drewblessing.com/blog/-/blogs/puppet-hiera-implement-defined-resource-types-in-hiera
- http://docs.puppetlabs.com/hiera/1/custom_backends.html
