### PR TITLE
Remove deprecated rds key now that rds_instances exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,27 +103,6 @@ Usage:
 cluster_nodes = hiera("memcached_cluster_nodes_for_cfn_stack")
 ```
 
-### rds tag=value...
-
-**Note: "rds" has been superseded by "rds_instances" (see below). It is still
-supported for backward compatibility, but will be removed in a future version.**
-
-Returns an array of all RDS database instances that have one or more tags. The
-returned array has the format `["host1", "host2"]`.
-
-Usage:
-
-```
-# Get all database instances
-rds_instances = hiera("rds")
-
-# Get all database instances that have a tag named "environment" with the value "dev"
-rds_instances = hiera("rds environment=dev")
-
-# Get all database instances that have two specific tags
-rds_instances = hiera("rds environment=production role=mgmt-db")
-```
-
 ### rds_instances tag=value...
 
 Returns an array of all RDS database instances that have one or more tags

--- a/lib/hiera/backend/aws/rds.rb
+++ b/lib/hiera/backend/aws/rds.rb
@@ -20,24 +20,13 @@ class Hiera
           return r if r
 
           args = key.split
-          subkey = args.shift
-
-          # TODO: "rds" has been superseded by "rds_instances" but is still
-          # supported for backward compatibility. Remove it in a future
-          # version.
-          if %w(rds rds_instances).include? subkey
+          if args.shift == "rds_instances"
             if args.length > 0
               tags = Hash[args.map { |t| t.split("=") }]
               db_instances_with_tags(tags)
             else
               db_instances
-            end.map do |i|
-              if subkey == "rds"
-                i[:endpoint][:address]
-              else
-                prepare_instance_data(i)
-              end
-            end
+            end.map { |i| prepare_instance_data(i) }
           end
         end
 

--- a/spec/aws_rds_spec.rb
+++ b/spec/aws_rds_spec.rb
@@ -58,36 +58,7 @@ class Hiera
         end
       end
 
-      # TODO: "rds" has been superseded by "rds_instances" but is still
-      # supported for backward compatibility. Remove it in a future
-      # version.
-      describe "rds lookup (deprecated)" do
-        let(:scope) { { "aws_account_number" => "12345678" } }
-
-        it "returns nil if Hiera key is unknown" do
-          expect(rds.lookup("doge", scope)).to be_nil
-        end
-
-        it "returns all database instances if no tags are provided" do
-          expect(rds.lookup("rds", scope)).to eq ["db1.some-region.rds.amazonaws.com",
-                                                  "db2.some-region.rds.amazonaws.com",
-                                                  "db3.some-region.rds.amazonaws.com"]
-        end
-
-        it "returns database instances with specific tags" do
-          expect(rds.lookup("rds role=mgmt-db", scope)).to eq ["db2.some-region.rds.amazonaws.com",
-                                                               "db3.some-region.rds.amazonaws.com"]
-          expect(rds.lookup("rds environment=dev", scope)).to eq ["db1.some-region.rds.amazonaws.com",
-                                                                  "db2.some-region.rds.amazonaws.com"]
-          expect(rds.lookup("rds environment=production role=mgmt-db", scope)).to eq ["db3.some-region.rds.amazonaws.com"]
-        end
-
-        it "returns empty array if no database instances can be found" do
-          expect(rds.lookup("rds environment=staging", scope)).to eq []
-        end
-      end
-
-      describe "rds_instances lookup" do
+      describe "#lookup" do
         let(:scope) { { "aws_account_number" => "12345678" } }
 
         it "returns nil if Hiera key is unknown" do


### PR DESCRIPTION
Related to c97eb34c77ff51a560e0c99e245477484660e49c

@s0enke Can be used in production as soon as we don't use the rds key anymore.
