### PR TITLE
Return Redis endpoint data using unified format

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,19 @@ The backend currently supports the following keys that you can pass to the
 
 Returns an array of all Redis cluster nodes for the CloudFormation stack of an
 EC2 instance. The instance is identified by the Puppet fact `$ec2_instance_id`.
-The returned array has the format `["host1", "host2"]`.
 
 Usage:
 
 ```
 cluster_nodes = hiera("redis_cluster_nodes_for_cfn_stack")
+```
+
+For each Redis cluster node in the array the following hash is returned:
+
+```json
+{
+    "endpoint" => { "address" => "some.redis.endpoint", "port" => 6379 },
+}
 ```
 
 ### redis_cluster_replica_groups_for_cfn_stack

--- a/spec/aws_elasticache_spec.rb
+++ b/spec/aws_elasticache_spec.rb
@@ -65,7 +65,10 @@ class Hiera
           allow(client).to receive(:describe_cache_clusters).and_return(cache_clusters)
           AWS::ElastiCache::Client.stub(:new => client)
 
-          expect(elasticache.redis_cluster_nodes_for_cfn_stack).to eq ["1.1.1.1", "2.2.2.2"]
+          expect(elasticache.redis_cluster_nodes_for_cfn_stack).to eq [
+            { "endpoint" => { "address" => "1.1.1.1", "port" => 1234 } },
+            { "endpoint" => { "address" => "2.2.2.2", "port" => 1234 } },
+          ]
         end
       end
 


### PR DESCRIPTION
This changes `redis_cluster_nodes_for_cfn_stack` to return endpoint address and port as a hash, which is the same format used elsewhere.

This allows us to use the result of `redis_cluster_nodes_for_cfn_stack` instead of `redis_cluster_replica_groups_for_cfn_stack` without changing the consumer code at all. In other words: We can use the cluster node in Puppet in case the replica group isn't available yet.
