### PR TITLE
Disable real HTTP connections with WebMock

### DIFF
--- a/hiera-aws.gemspec
+++ b/hiera-aws.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop", "~> 0.21.0"
+  spec.add_development_dependency "webmock"
 end

--- a/spec/aws_backend_spec.rb
+++ b/spec/aws_backend_spec.rb
@@ -1,3 +1,4 @@
+require "spec_helper"
 require "hiera/backend/aws_backend"
 
 class Hiera

--- a/spec/aws_base_spec.rb
+++ b/spec/aws_base_spec.rb
@@ -1,3 +1,4 @@
+require "spec_helper"
 require "hiera/backend/aws/base"
 
 class Hiera

--- a/spec/aws_elasticache_spec.rb
+++ b/spec/aws_elasticache_spec.rb
@@ -1,3 +1,4 @@
+require "spec_helper"
 require "hiera/backend/aws/elasticache"
 
 class Hiera

--- a/spec/aws_rds_spec.rb
+++ b/spec/aws_rds_spec.rb
@@ -1,3 +1,4 @@
+require "spec_helper"
 require "hiera/backend/aws/rds"
 
 class Hiera

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+# Disable real HTTP connections and tell us exactly what requests are made.
+require "webmock/rspec"


### PR DESCRIPTION
In addition to disabling HTTP requests while testing, [WebMock](https://github.com/bblimke/webmock) also tells us what requests are being made during a test run, e.g.

```
Failures:

  1) Hiera::Backend::Aws::RDS#lookup returns all database instances if no tags are provided
     Failure/Error: expect(rds.lookup("rds_instances", scope)).to eq [
     WebMock::NetConnectNotAllowedError:
       Real HTTP connections are disabled. Unregistered request: POST https://rds.eu-west-1.amazonaws.com/ with body
...
```
