### PR TITLE
Depend on aws-sdk v1

### DIFF
--- a/hiera-aws.gemspec
+++ b/hiera-aws.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk"
+  spec.add_dependency "aws-sdk", "~> 1.63"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Without pinning, v2 will be installed, which we do not support yet.

Fixes #26.