### PR TITLE
use aws-sdk-v1 instead of aws-sdk

### DIFF
--- a/lib/hiera/backend/aws/base.rb
+++ b/lib/hiera/backend/aws/base.rb
@@ -1,4 +1,4 @@
-require "aws-sdk"
+require "aws-sdk-v1"
 
 class Hiera
   module Backend

--- a/lib/hiera/backend/aws_backend.rb
+++ b/lib/hiera/backend/aws_backend.rb
@@ -8,10 +8,10 @@ class Hiera
     class Aws_backend # rubocop:disable ClassAndModuleCamelCase
       def initialize
         begin
-          require "aws-sdk"
+          require "aws-sdk-v1"
         rescue LoadError
           require "rubygems"
-          require "aws-sdk"
+          require "aws-sdk-v1"
         end
 
         setup_aws_config


### PR DESCRIPTION
Changed aws-sdk to use aws-sdk-v1, so if you want to load v1 and v2 of the Ruby SDK in the same application.